### PR TITLE
fix: correct service section markup

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,7 +125,7 @@ Providing expert services in fish habitat assessment, watercourse alteration per
                         <img src="FPA.png" alt="Icon representing improved fish passage through a culvert." class="h-16 w-16 mb-4 self-center">
                         <h3 class="text-xl font-bold mb-3 text-brand-accent text-center">Fish Passage Assessment & Design</h3>
                         <p class="text-gray-600 text-center flex-grow">
-                            We assess barriers to fish passage like culverts dams and other barriers and design and impliment effective solutions.
+                            We assess barriers to fish passage like culverts, dams, and other obstacles, and design and implement effective solutions.
                         </p>
                     </div>
                     <div class="bg-white p-8 rounded-lg shadow-lg hover:shadow-xl hover:-translate-y-1 transition-all duration-300 flex flex-col">
@@ -146,7 +146,7 @@ Providing expert services in fish habitat assessment, watercourse alteration per
                         <img src="DSGIS.png" alt="Icon of a drone surveying a watercourse." class="h-16 w-16 mb-4 self-center">
                         <h3 class="text-xl font-bold mb-3 text-brand-accent text-center">Drone Surveying & GIS</h3>
                         <p class="text-gray-600 text-center flex-grow">
-                            High-resolution aerial imagery, topographic mapping (Photogrammetry) and advanced GIS analysis for site planning, habitat monitoring, and more.                        </p>
+                            High-resolution aerial imagery, topographic mapping (Photogrammetry) and advanced GIS analysis for site planning, habitat monitoring, and more.
                         </p>
                     </div>
                     <div class="bg-white p-8 rounded-lg shadow-lg hover:shadow-xl hover:-translate-y-1 transition-all duration-300 flex flex-col">


### PR DESCRIPTION
## Summary
- fix fish passage service description to remove typo and improve readability
- remove stray paragraph tag in drone surveying card

## Testing
- `tidy -e -q index.html` *(command not found)*
- `apt-get update` *(failed: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6896bda1932883329d974ab1e8c069b1