### PR TITLE
Move inline styles to standalone stylesheet

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,16 +54,7 @@
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700;800&display=swap" rel="stylesheet">
 
-    <style>
-        body { font-family: 'Inter', sans-serif; }
-        .bg-brand-dark { background-color: #0d3b4c; }
-        .bg-brand-accent { background-color: #009ddc; }
-        .bg-brand-accent-hover:hover { background-color: #008ac7; }
-        .text-brand-dark { color: #0d3b4c; }
-        .text-brand-accent { color: #009ddc; }
-        .fade-in-up { opacity: 0; transform: translateY(30px); transition: opacity 0.6s ease-out, transform 0.6s ease-out; }
-        .fade-in-up.visible { opacity: 1; transform: translateY(0); }
-    </style>
+    <link rel="stylesheet" href="styles.css">
 </head>
 <body class="bg-gray-100 text-gray-700">
 

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,8 @@
+body { font-family: 'Inter', sans-serif; }
+.bg-brand-dark { background-color: #0d3b4c; }
+.bg-brand-accent { background-color: #009ddc; }
+.bg-brand-accent-hover:hover { background-color: #008ac7; }
+.text-brand-dark { color: #0d3b4c; }
+.text-brand-accent { color: #009ddc; }
+.fade-in-up { opacity: 0; transform: translateY(30px); transition: opacity 0.6s ease-out, transform 0.6s ease-out; }
+.fade-in-up.visible { opacity: 1; transform: translateY(0); }


### PR DESCRIPTION
## Summary
- move CSS from `<style>` block in `index.html` to new `styles.css`
- link external stylesheet in `index.html`

## Testing
- `python3 -m http.server 8000 >/tmp/server.log 2>&1 &` then `curl -I http://localhost:8000/index.html` and `curl -I http://localhost:8000/styles.css`
- `rg "fade-in-up" -n`
- `rg "bg-brand-dark" -n`


------
https://chatgpt.com/codex/tasks/task_e_6896c109ca048332b8cb714bba9536d6