### PR TITLE
Add Jest test for footer year display

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "aquahabwebsite",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "jsdom": "^22.1.0"
+  }
+}

--- a/tests/footerYear.test.js
+++ b/tests/footerYear.test.js
@@ -1,0 +1,31 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+describe('footer year', () => {
+  it('sets #year to the current year', () => {
+    const html = fs.readFileSync(path.resolve(__dirname, '../index.html'), 'utf8');
+    const dom = new JSDOM(html, { runScripts: 'outside-only' });
+    const { window } = dom;
+
+    // Mock IntersectionObserver for jsdom environment
+    window.IntersectionObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+
+    const testYear = 2000;
+    jest.useFakeTimers().setSystemTime(new Date(`${testYear}-01-01`));
+
+    // Execute the footer script from index.html
+    const scripts = window.document.querySelectorAll('script');
+    const footerScript = scripts[scripts.length - 1].textContent;
+    window.eval(footerScript);
+
+    const yearEl = window.document.getElementById('year');
+    expect(yearEl.textContent).toBe(String(testYear));
+
+    jest.useRealTimers();
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest and jsdom dev dependencies with npm test script
- create footerYear.test.js to verify footer year from index.html script
- add .gitignore for node_modules

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896c123d08083329482c7508af0a4df