### PR TITLE
Add robots.txt and sitemap for domain root

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Allow: /
+Sitemap: https://your-domain.example/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://your-domain.example/</loc>
+  </url>
+</urlset>

--- a/tests/footerYear.test.js
+++ b/tests/footerYear.test.js
@@ -17,6 +17,7 @@ describe('footer year', () => {
 
     const testYear = 2000;
     jest.useFakeTimers().setSystemTime(new Date(`${testYear}-01-01`));
+    window.Date = Date;
 
     // Execute the footer script from index.html
     const scripts = window.document.querySelectorAll('script');


### PR DESCRIPTION
## Summary
- add robots.txt allowing all crawlers and pointing to sitemap
- generate static sitemap.xml listing the site root URL
- fix footer year test to use mocked Date so Jest timers work

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896c51f348083329d1f30f8ac215080