### PR TITLE
Add canonical and social metadata to head

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,6 +16,15 @@
     <title>AquaHab Environmental | Fish Passage, Watercourse Alteration &amp; Permitting NS</title>
     
     <meta name="description" content="Expert environmental consulting in Nova Scotia. Specializing in watercourse alteration permits, fish passage design, wetland delineation, and DFO-compliant fish rescue/salvage services.">
+    <link rel="canonical" href="https://your-domain.example/">
+    <meta property="og:title" content="AquaHab Environmental | Fish Passage, Watercourse Alteration &amp; Permitting NS">
+    <meta property="og:description" content="Expert environmental consulting in Nova Scotia. Specializing in watercourse alteration permits, fish passage design, wetland delineation, and DFO-compliant fish rescue/salvage services.">
+    <meta property="og:url" content="https://your-domain.example/">
+    <meta property="og:image" content="https://your-domain.example/Logo_Long.png">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="AquaHab Environmental | Fish Passage, Watercourse Alteration &amp; Permitting NS">
+    <meta name="twitter:description" content="Expert environmental consulting in Nova Scotia. Specializing in watercourse alteration permits, fish passage design, wetland delineation, and DFO-compliant fish rescue/salvage services.">
+    <meta name="twitter:image" content="https://your-domain.example/Logo_Long.png">
 
     <script type="application/ld+json">
     {

--- a/tests/footerYear.test.js
+++ b/tests/footerYear.test.js
@@ -17,6 +17,7 @@ describe('footer year', () => {
 
     const testYear = 2000;
     jest.useFakeTimers().setSystemTime(new Date(`${testYear}-01-01`));
+    window.Date = Date;
 
     // Execute the footer script from index.html
     const scripts = window.document.querySelectorAll('script');


### PR DESCRIPTION
## Summary
- add canonical link and Open Graph/Twitter tags to head for SEO and social sharing
- ensure footer year test uses mocked Date so it reflects fake timers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6896c51920388332894e33ab2ca8480f