### PR TITLE
Lazy load offscreen images

### DIFF
--- a/index.html
+++ b/index.html
@@ -111,7 +111,7 @@ Providing expert services in fish habitat assessment, watercourse alteration per
                         </p>
                     </div>
                     <div>
-                        <img src="field_image.jpg" alt="AquaHab environmental consultant conducting a fish habitat assessment in a Nova Scotia stream for a linear development project." class="rounded-lg shadow-xl w-full h-auto">
+                        <img src="field_image.jpg" alt="AquaHab environmental consultant conducting a fish habitat assessment in a Nova Scotia stream for a linear development project." loading="lazy" class="rounded-lg shadow-xl w-full h-auto">
                     </div>
                 </div>
             </div>
@@ -125,42 +125,42 @@ Providing expert services in fish habitat assessment, watercourse alteration per
                 </div>
                 <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
                     <div class="bg-white p-8 rounded-lg shadow-lg hover:shadow-xl hover:-translate-y-1 transition-all duration-300 flex flex-col">
-                        <img src="FPA.png" alt="Icon representing improved fish passage through a culvert." class="h-16 w-16 mb-4 self-center">
+                        <img src="FPA.png" alt="Icon representing improved fish passage through a culvert." loading="lazy" class="h-16 w-16 mb-4 self-center">
                         <h3 class="text-xl font-bold mb-3 text-brand-accent text-center">Fish Passage Assessment & Design</h3>
                         <p class="text-gray-600 text-center flex-grow">
                             We assess barriers to fish passage like culverts, dams, and other obstacles, and design and implement effective solutions.
                         </p>
                     </div>
                     <div class="bg-white p-8 rounded-lg shadow-lg hover:shadow-xl hover:-translate-y-1 transition-all duration-300 flex flex-col">
-                        <img src="FH.png" alt="Icon representing a detailed fish habitat map." class="h-16 w-16 mb-4 self-center">
+                        <img src="FH.png" alt="Icon representing a detailed fish habitat map." loading="lazy" class="h-16 w-16 mb-4 self-center">
                         <h3 class="text-xl font-bold mb-3 text-brand-accent text-center">Habitat Assessment & Offsetting</h3>
                         <p class="text-gray-600 text-center flex-grow">
                             Conducting detailed fish habitat assessments for DFO Requests for Review or culvert or bridge construction. We design and implement effective, compliant offsetting and habitat compensation plans.
                         </p>
                     </div>
                     <div class="bg-white p-8 rounded-lg shadow-lg hover:shadow-xl hover:-translate-y-1 transition-all duration-300 flex flex-col">
-                        <img src="WLA.png" alt="Icon showing wetland boundaries being delineated on a map." class="h-16 w-16 mb-4 self-center">
+                        <img src="WLA.png" alt="Icon showing wetland boundaries being delineated on a map." loading="lazy" class="h-16 w-16 mb-4 self-center">
                         <h3 class="text-xl font-bold mb-3 text-brand-accent text-center">Wetland Assessment & Delineation</h3>
                         <p class="text-gray-600 text-center flex-grow">
                             Professional Wetland Delineation and/or assessment services for projects in Nova Scotia. Certified in WESP-AC. We handle provincial wetland alteration applications.
                         </p>
                     </div>
                     <div class="bg-white p-8 rounded-lg shadow-lg hover:shadow-xl hover:-translate-y-1 transition-all duration-300 flex flex-col">
-                        <img src="DSGIS.png" alt="Icon of a drone surveying a watercourse." class="h-16 w-16 mb-4 self-center">
+                        <img src="DSGIS.png" alt="Icon of a drone surveying a watercourse." loading="lazy" class="h-16 w-16 mb-4 self-center">
                         <h3 class="text-xl font-bold mb-3 text-brand-accent text-center">Drone Surveying & GIS</h3>
                         <p class="text-gray-600 text-center flex-grow">
                             High-resolution aerial imagery, topographic mapping (Photogrammetry) and advanced GIS analysis for site planning, habitat monitoring, and more.
                         </p>
                     </div>
                     <div class="bg-white p-8 rounded-lg shadow-lg hover:shadow-xl hover:-translate-y-1 transition-all duration-300 flex flex-col">
-                        <img src="WCA.png" alt="Icon of a permit for a watercourse alteration." class="h-16 w-16 mb-4 self-center">
+                        <img src="WCA.png" alt="Icon of a permit for a watercourse alteration." loading="lazy" class="h-16 w-16 mb-4 self-center">
                         <h3 class="text-xl font-bold mb-3 text-brand-accent text-center">Watercourse Alterations & Fish Rescue</h3>
                         <p class="text-gray-600 text-center flex-grow">
                             Certified expertise for watercourse alteration permits. We also provide electrofishing fish rescue services for construction dewatering and instream work.
                         </p>
                     </div>
                     <div class="bg-white p-8 rounded-lg shadow-lg hover:shadow-xl hover:-translate-y-1 transition-all duration-300 flex flex-col">
-                        <img src="PDT.png" alt="Icon representing a training certificate for environmental best practices." class="h-16 w-16 mb-4 self-center">
+                        <img src="PDT.png" alt="Icon representing a training certificate for environmental best practices." loading="lazy" class="h-16 w-16 mb-4 self-center">
                         <h3 class="text-xl font-bold mb-3 text-brand-accent text-center">Professional Training</h3>
                         <p class="text-gray-600 text-center flex-grow">
                             Customized training for you or your team. 

--- a/tests/footerYear.test.js
+++ b/tests/footerYear.test.js
@@ -18,6 +18,9 @@ describe('footer year', () => {
     const testYear = 2000;
     jest.useFakeTimers().setSystemTime(new Date(`${testYear}-01-01`));
 
+    // Ensure the JSDOM window uses the mocked Date
+    window.Date = Date;
+
     // Execute the footer script from index.html
     const scripts = window.document.querySelectorAll('script');
     const footerScript = scripts[scripts.length - 1].textContent;


### PR DESCRIPTION
## Summary
- defer loading of below-the-fold images with `loading="lazy"`
- ensure footer year test uses mocked Date in JSDOM

## Testing
- `npm test`
- `node -e "const fs=require('fs');const {JSDOM}=require('jsdom');const html=fs.readFileSync('index.html','utf8');const dom=new JSDOM(html,{ runScripts:'outside-only'});const lazy=dom.window.document.querySelectorAll('img[loading=lazy]');console.log('lazy imgs',lazy.length);"`
- Attempted: `npm install puppeteer --no-save` *(failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6896c529b8c4833287bf0facb67a85ba